### PR TITLE
Fix that typo in the usage message

### DIFF
--- a/imgur-screenshot.sh
+++ b/imgur-screenshot.sh
@@ -374,7 +374,7 @@ while [ $# != 0 ]; do
     echo "  -l, --login=true|false    override 'login' config. -l implies true"
     echo "  -k, --keep=true|false     override 'keep_file' config. -k implies true"
     echo "  -d, --auto-delete <s>     automatically delete image after <s> seconds"
-    echo "  file                      upload file isntead of taking a screenshot"
+    echo "  file                      upload file instead of taking a screenshot"
     exit 0;;
   -v | --version)
     echo "$current_version"


### PR DESCRIPTION
This PR aims to fix a possible typing error in the usage message displayed upon invoking `imgur-screenshot --help`. It does so by replacing the word `isntead` with `instead`, which seems to be what the author of the message meant. (It is spelled correctly in the readme)

This commit is essential for the survival of this project because proper spelling implies a professional distributed cloud Quality Assurance team, which helps users build confidence in this product.

Thanks!