### PR TITLE
Added basic album support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Bind the script to a hotkey or add it to your $PATH for quick access ;)
 Usage
 ----
 ```bash
-imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]] | [[-o | --open=true|false] [-e | --edit=true|false] [-l | --login=true|false] [-A <album_id> | --album_id <album_id>] [-k | --keep_file=true|false] [-d <s> | --auto-delete <s>] [file ...]]
+imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]] | [[-o | --open=true|false] [-e | --edit=true|false] [-l | --login=true|false] [[-a <album_title> | --album <album_title>] | [-A <album_id> | --album_id <album_id>]] [-k | --keep_file=true|false] [-d <s> | --auto-delete <s>] [file ...]]
 ```
 
 | short    | command                 | description                                             |
@@ -52,7 +52,8 @@ imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]]
 | -o       | --open=true\|false      | override *open* config <br> -o is equal to --open=true  |
 | -e       | --edit=true\|false      | override *edit* config <br> -e is equal to --edit=true  |
 | -l       | --login=true\|false     | override *login* config <br> -lis equal to --login=true |
-| -A       | --album_id \<album_id\> | override *album_id* config                                 |
+| -a       | --album \<album_title\> | Create new album and upload there                       |
+| -A       | --album_id \<album_id\> | override *album_id* config                              |
 | -k       | --keep_file=true\|false | override *keep_file* config                             |
 | -d \<s\> | --auto-delete \<s\>     | automatically delete image after `s` seconds            |
 | -u       | --update                | check for updates, exit                                 |
@@ -111,6 +112,7 @@ imgur_icon_path="$HOME/Pictures/imgur.png"
 imgur_acct_key=""
 imgur_secret=""
 login="false"
+album=""
 album_id=""
 credentials_file="$HOME/.config/imgur-screenshot/credentials.conf"
 file_name_format="imgur-%Y_%m_%d-%H:%M:%S.png" # when using scrot, must end with .png!
@@ -124,6 +126,7 @@ edit_command="gimp %img"
 edit="false"
 exit_on_selection_fail="true"
 edit_on_selection_fail="false"
+exit_on_album_creation_fail="true"
 open_command="xdg-open %url" # OS X: "open %url"
 open="true"
 log_file="$HOME/.imgur-screenshot.log"
@@ -154,6 +157,9 @@ check_update="true"
 
   > If set to true, the script will try to upload to your account
 
+* album
+
+  > If set, the script will try to create a new album and upload to that specific album on your account (requires login)
 * album_id
 
   > If set, the script will try to upload to that specific album on your account (requires login)
@@ -212,6 +218,10 @@ check_update="true"
 * edit_on_selection_fail
 
   > When *exit_on_selection_fail* is *false* and the selective screenshot fails, open the (full screen) image with edit_command.
+
+* exit_on_album_creation_fail
+
+  > If set to false upload images even if the album creation failed.
 
 * open_command
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Bind the script to a hotkey or add it to your $PATH for quick access ;)
 Usage
 ----
 ```bash
-imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]] | [[-o | --open=true|false] [-e | --edit=true|false] [-l | --login=true|false] [-k | --keep_file=true|false] [-d <s> | --auto-delete <s>] [file ...]]
+imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]] | [[-o | --open=true|false] [-e | --edit=true|false] [-l | --login=true|false] [-a <album> | --album <album>] [-k | --keep_file=true|false] [-d <s> | --auto-delete <s>] [file ...]]
 ```
 
 | short    | command                 | description                                             |
@@ -52,6 +52,7 @@ imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]]
 | -o       | --open=true\|false      | override *open* config <br> -o is equal to --open=true  |
 | -e       | --edit=true\|false      | override *edit* config <br> -e is equal to --edit=true  |
 | -l       | --login=true\|false     | override *login* config <br> -lis equal to --login=true |
+| -a       | --album \<album\>       | override *album* config                                 |
 | -k       | --keep_file=true\|false | override *keep_file* config                             |
 | -d \<s\> | --auto-delete \<s\>     | automatically delete image after `s` seconds            |
 | -u       | --update                | check for updates, exit                                 |
@@ -110,6 +111,7 @@ imgur_icon_path="$HOME/Pictures/imgur.png"
 imgur_acct_key=""
 imgur_secret=""
 login="false"
+album=""
 credentials_file="$HOME/.config/imgur-screenshot/credentials.conf"
 file_name_format="imgur-%Y_%m_%d-%H:%M:%S.png" # when using scrot, must end with .png!
 file_dir="$HOME/Pictures"
@@ -151,6 +153,10 @@ check_update="true"
 * login
 
   > If set to true, the script will try to upload to your account
+
+* album
+
+  > If set, the script will try to upload to that specific album on your account (requires login)
 
 * credentials_file
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Bind the script to a hotkey or add it to your $PATH for quick access ;)
 Usage
 ----
 ```bash
-imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]] | [[-o | --open=true|false] [-e | --edit=true|false] [-l | --login=true|false] [-a <album> | --album <album>] [-k | --keep_file=true|false] [-d <s> | --auto-delete <s>] [file ...]]
+imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]] | [[-o | --open=true|false] [-e | --edit=true|false] [-l | --login=true|false] [-A <album_id> | --album_id <album_id>] [-k | --keep_file=true|false] [-d <s> | --auto-delete <s>] [file ...]]
 ```
 
 | short    | command                 | description                                             |
@@ -52,7 +52,7 @@ imgur-screenshot [[-c | --connect] | --check | [-v | --version] | [-h | --help]]
 | -o       | --open=true\|false      | override *open* config <br> -o is equal to --open=true  |
 | -e       | --edit=true\|false      | override *edit* config <br> -e is equal to --edit=true  |
 | -l       | --login=true\|false     | override *login* config <br> -lis equal to --login=true |
-| -a       | --album \<album\>       | override *album* config                                 |
+| -A       | --album_id \<album_id\> | override *album_id* config                                 |
 | -k       | --keep_file=true\|false | override *keep_file* config                             |
 | -d \<s\> | --auto-delete \<s\>     | automatically delete image after `s` seconds            |
 | -u       | --update                | check for updates, exit                                 |
@@ -111,7 +111,7 @@ imgur_icon_path="$HOME/Pictures/imgur.png"
 imgur_acct_key=""
 imgur_secret=""
 login="false"
-album=""
+album_id=""
 credentials_file="$HOME/.config/imgur-screenshot/credentials.conf"
 file_name_format="imgur-%Y_%m_%d-%H:%M:%S.png" # when using scrot, must end with .png!
 file_dir="$HOME/Pictures"
@@ -154,7 +154,7 @@ check_update="true"
 
   > If set to true, the script will try to upload to your account
 
-* album
+* album_id
 
   > If set, the script will try to upload to that specific album on your account (requires login)
 

--- a/imgur-screenshot.sh
+++ b/imgur-screenshot.sh
@@ -16,7 +16,7 @@ imgur_icon_path="$HOME/Pictures/imgur.png"
 imgur_acct_key=""
 imgur_secret=""
 login="false"
-album=""
+album_id=""
 credentials_file="$HOME/.config/imgur-screenshot/credentials.conf"
 
 file_name_format="imgur-%Y_%m_%d-%H:%M:%S.png" # when using scrot, must end with .png!
@@ -262,10 +262,10 @@ function delete_image() {
 function upload_authenticated_image() {
   echo "Uploading '$1'..."
   title="$(echo "$1" | rev | cut -d "/" -f 1 | cut -d "." -f 2- | rev)"
-  if [ -n "$album" ]; then
-    album_opt="-F album=$album"
+  if [ -n "$album_id" ]; then
+    album_id_opt="-F album=$album_id"
   fi
-  response="$(curl --compressed --connect-timeout "$upload_connect_timeout" -m "$upload_timeout" --retry "$upload_retries" -fsSL --stderr - -F "title=$title" -F "image=@$1" "$album_opt" -H "Authorization: Bearer $access_token" https://api.imgur.com/3/image)"
+  response="$(curl --compressed --connect-timeout "$upload_connect_timeout" -m "$upload_timeout" --retry "$upload_retries" -fsSL --stderr - -F "title=$title" -F "image=@$1" "$album_id_opt" -H "Authorization: Bearer $access_token" https://api.imgur.com/3/image)"
 
   # JSON parser premium edition (not really)
   if egrep -q '"success":\s*true' <<<"$response"; then
@@ -357,7 +357,7 @@ while [ $# != 0 ]; do
     echo "  -o, --open=true|false     override 'open' config. -o implies true"
     echo "  -e, --edit=true|false     override 'edit' config. -e implies true"
     echo "  -l, --login=true|false    override 'login' config. -l implies true"
-    echo "  -a, --album=album      upload image to a specific album"
+	echo "  -A, --album_id=album_id   override 'album_id' config"
     echo "  -k, --keep=true|false     override 'keep_file' config. -k implies true"
     echo "  -d, --auto-delete <s>     automatically delete image after <s> seconds"
     echo "  file                      upload file instead of taking a screenshot"
@@ -388,8 +388,8 @@ while [ $# != 0 ]; do
     load_access_token
     fetch_account_info
     exit 0;;
-  -a | --album)
-    album="$2"
+  -A | --album_id)
+    album_id="$2"
     shift 2;;
   -k | --keep_file=true)
     keep_file="true"


### PR DESCRIPTION
Added basic albums support: upload to existing album, I've implemented a couple of other things (single/multi-head screenshots) in my [scrennshot-taker/uploader](https://bitbucket.org/Treferwynd/tscreen), but I think that's too much tailored around my needs.

Anyway, thanks for the script, it's super useful!

P.S. [Here](https://aur.archlinux.org/packages/imgur-screenshot-git/) I found this [.destkop](https://bitbucket.org/Treferwynd/tscreen/raw/master/PKGBUILD/imgur-screenshot.desktop), add this to the MIME definitions and you can upload images from the context menu!