### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Dependencies
 * scrot
 * xclip <i>(needed for `copy_url`)</i>
 * **OS X only:**
-* [terminal-notifier](https://github.com/alloy/terminal-notifier) *or* [growlnotify](http://growl.info/downloads#generaldownloads)
+* [terminal-notifier](https://github.com/julienXX/terminal-notifier) *or* [growlnotify](http://growl.info/downloads#generaldownloads)
 
 
 OS support


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/alloy/terminal-notifier | https://github.com/julienXX/terminal-notifier 
