### PR TITLE
fix '--keep_file' option

### DIFF
--- a/imgur-screenshot.sh
+++ b/imgur-screenshot.sh
@@ -17,7 +17,7 @@ if [ "$1" = "--debug" ]; then
   set -x
 fi
 
-current_version="v1.6.0"
+current_version="v1.6.1"
 
 function is_mac() {
   uname | grep -q "Darwin"
@@ -394,18 +394,18 @@ while [ $# != 0 ]; do
     echo "usage: $0 [--connect | --check | [-v | --version] | [-h | --help] ] |"
     echo "  [[-o | --open <true|false>] [-e | --edit <true|false>] [-l | --login <true|false>] [[-a <album_title> | --album <album_title>] | [-A <album_id> | --album_id <album_id>]] [-k | --keep_file <true|false>] [-d <s> | --auto-delete <s>] [file ...]]"
     echo ""
-    echo "  -h, --help                show this help, exit"
-    echo "  -v, --version             show current version, exit"
-    echo "      --check               Check if all dependencies are installed, exit"
-    echo "  -c, --connect             Show connected imgur account, exit"
-    echo "  -o, --open <true|false>   override 'open' config. -o implies true"
-    echo "  -e, --edit <true|false>   override 'edit' config. -e implies true"
-    echo "  -l, --login <true|false>  override 'login' config. -l implies true"
-    echo "  -a, --album <album_title> Create new album and upload there"
-    echo "  -A, --album_id <album_id> override 'album_id' config"
-    echo "  -k, --keep <true|false>   override 'keep_file' config. -k implies true"
-    echo "  -d, --auto-delete <s>     automatically delete image after <s> seconds"
-    echo "  file                      upload file instead of taking a screenshot"
+    echo "  -h, --help                   show this help, exit"
+    echo "  -v, --version                show current version, exit"
+    echo "      --check                  Check if all dependencies are installed, exit"
+    echo "  -c, --connect                Show connected imgur account, exit"
+    echo "  -o, --open <true|false>      override 'open' config. -o implies true"
+    echo "  -e, --edit <true|false>      override 'edit' config. -e implies true"
+    echo "  -l, --login <true|false>     override 'login' config. -l implies true"
+    echo "  -a, --album <album_title>    Create new album and upload there"
+    echo "  -A, --album_id <album_id>    override 'album_id' config"
+    echo "  -k, --keep_file <true|false> override 'keep_file' config. -k implies true"
+    echo "  -d, --auto-delete <s>        automatically delete image after <s> seconds"
+    echo "  file                         upload file instead of taking a screenshot"
     exit 0;;
   -v | --version)
     echo "$current_version"


### PR DESCRIPTION
The long line from usage was correct (`--keep_file`) but the separate instructions were not (showed `--keep`, which would produce an error, since it’d look for a file).