### PR TITLE
added --edit-command flag

### DIFF
--- a/imgur-screenshot.sh
+++ b/imgur-screenshot.sh
@@ -401,6 +401,7 @@ while [ ${#} != 0 ]; do
     echo "  -c, --connect                Show connected imgur account, exit"
     echo "  -o, --open <true|false>      Override 'open' config"
     echo "  -e, --edit <true|false>      Override 'edit' config"
+    echo "  -i, --edit-command <command> Override 'edit_command' config (include '%img'), sets --edit 'true'"
     echo "  -l, --login <true|false>     Override 'login' config"
     echo "  -a, --album <album_title>    Create new album and upload there"
     echo "  -A, --album-id <album_id>    Override 'album_id' config"
@@ -426,6 +427,10 @@ while [ ${#} != 0 ]; do
     shift 2;;
   -e | --edit)
     edit="${2}"
+    shift 2;;
+  -i | --edit-command)
+    edit_command="${2}"
+    edit="true"
     shift 2;;
   -l | --login)
     login="${2}"


### PR DESCRIPTION
Had to make some assumptions, but let me know if I should revert any of them.

It also sets `--edit 'true'`, because why would a user set `--edit-command` if they didn’t actually want to edit? If they set `--edit-command` and nothing happened (because the default is to not edit), it would be more confusing. If one really want to set an `--edit-command` but still not edit for some reason, it’s still possible to explicitly add `--edit 'false'` after it, and it’ll work.

At first I excluded the need to actually type `%img` when setting `--edit-command`, by making it `edit_command="${2} %img"` instead of `edit_command="${2}"`, since there’s a chance a user may forget what the exact thing is to write, if they’re not too familiar with the internals. However, that takes away the ability to make more complex commands, where `%img` is in the middle of a pipe, or something, so I added the message to “include '%img'”. At first I wrote something more complex (“use '%img' as a placeholder to the image's path”), but that makes the instruction too long. As it is, it should be clear enough, as `%img` should be understandable from its name, and from the site’s documentation.