### PR TITLE
Fixed a race condition affecting scrot

### DIFF
--- a/imgur-screenshot.sh
+++ b/imgur-screenshot.sh
@@ -127,8 +127,8 @@ function take_screenshot() {
 
   cmd="screenshot_${mode}_command"
   cmd=${!cmd//\%img/${1}}
-
-  shot_err="$(${cmd} &>/dev/null)" #takes a screenshot with selection
+  #sleep for 0.1 to eliminate a race condition in scrot that can occur when executing from keybind
+  shot_err="$(sleep 0.1 && ${cmd} &>/dev/null)" #takes a screenshot with selection
   if [ "${?}" != "0" ]; then
     echo "Failed to take screenshot '${1}': '${shot_err}'. For more information visit https://github.com/jomo/imgur-screenshot/wiki/Troubleshooting" | tee -a "${log_file}"
     notify error "Something went wrong :(" "Information has been logged"


### PR DESCRIPTION
Fixed a race condition affecting scrot

Race condition occurs in scrot where it is unable to
acquire a necessary resource from the keyboard.

This happens when you bind the command to a key.

Details about this race condition can be found here:

https://bbs.archlinux.org/viewtopic.php?id=86507
https://code.google.com/archive/p/xmonad/issues/476

