### PR TITLE
Add reference to new stable package in Arch Linux's AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ brew update && brew install imgur-screenshot
 
 ### Install on ArchLinux via AUR
 
-See the [imgur-screenshot-git](https://aur.archlinux.org/packages/imgur-screenshot-git/) package.
+See [imgur-screenshot](https://aur.archlinux.org/packages/imgur-screenshot/) for the stable version, and [imgur-screenshot-git](https://aur.archlinux.org/packages/imgur-screenshot-git/) for the development version.
 
 ### Install on CentOS and Fedora via COPR
 


### PR DESCRIPTION
Arch Linux's AUR now has a package for the stable version. The previous package mentioned was just for the "development" version, i.e. latest commit