### PR TITLE
Fix scrot's frame being in the screenshot

### DIFF
--- a/imgur-screenshot
+++ b/imgur-screenshot
@@ -53,7 +53,7 @@ load_default_config() {
     declare -g OPEN_COMMAND="open %url"
     declare -g CLIPBOARD_COMMAND="pbcopy"
   else
-    declare -g SCREENSHOT_SELECT_COMMAND="scrot -s %img"
+    declare -g SCREENSHOT_SELECT_COMMAND="scrot -a $(slop -f '%x,%y,%w,%h') %img"
     declare -g SCREENSHOT_WINDOW_COMMAND="scrot -s -b %img" # -u is not universally supported
     declare -g SCREENSHOT_FULL_COMMAND="scrot %img"
     declare -g OPEN_COMMAND="xdg-open %url"


### PR DESCRIPTION
On my Arch Linux install, imgur-screenshot would capture its own frame. I fixed it as said in this issue: https://github.com/dreamer/scrot/issues/2#issuecomment-521963518